### PR TITLE
Add define for input system

### DIFF
--- a/InputGlyphs/Assets/InputGlyphs/Samples/InputCheckSample/Scripts/InputCheckSample.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Samples/InputCheckSample/Scripts/InputCheckSample.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System;
 using System.Collections.Generic;
 using InputGlyphs.Display;

--- a/InputGlyphs/Assets/InputGlyphs/Samples/InputCheckSample/Scripts/InputGlyphs.Sample.InputCheck.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Samples/InputCheckSample/Scripts/InputGlyphs.Sample.InputCheck.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Core/IInputGlyphLoader.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Core/IInputGlyphLoader.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Core/InputGlyphManager.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Core/InputGlyphManager.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Core/InputGlyphs.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Core/InputGlyphs.asmdef
@@ -11,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/DisplayGlyphTextureGenerator.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/DisplayGlyphTextureGenerator.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using InputGlyphs.Utils;
 using UnityEngine;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/InputGlyphs.Display.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/InputGlyphs.Display.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/Sprite/InputGlyphSprite.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/Sprite/InputGlyphSprite.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using InputGlyphs.Utils;
 using UnityEngine;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/Sprite/InputGlyps.Display.Sprite.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/Sprite/InputGlyps.Display.Sprite.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/Editor/InputGlyphTextEditor.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/Editor/InputGlyphTextEditor.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM && SUPPORT_TMPRO
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM && SUPPORT_TMPRO
 using System.Text;
 using UnityEditor;
 using UnityEngine;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/Editor/InputGlyphs.Display.TextMeshPro.Editor.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/Editor/InputGlyphs.Display.TextMeshPro.Editor.asmdef
@@ -16,6 +16,11 @@
     "defineConstraints": [],
     "versionDefines": [
         {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        },
+        {
             "name": "com.unity.textmeshpro",
             "expression": "",
             "define": "SUPPORT_TMPRO"

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/InputGlyphText.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/InputGlyphText.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM && SUPPORT_TMPRO
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM && SUPPORT_TMPRO
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/InputGlyphs.Display.TextMeshPro.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/TextMeshPro/InputGlyphs.Display.TextMeshPro.asmdef
@@ -17,6 +17,11 @@
     "defineConstraints": [],
     "versionDefines": [
         {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        },
+        {
             "name": "com.unity.textmeshpro",
             "expression": "",
             "define": "SUPPORT_TMPRO"

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/UI/InputGlyphImage.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/UI/InputGlyphImage.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using InputGlyphs.Utils;
 using UnityEngine;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Display/UI/InputGlyphs.Display.UI.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Display/UI/InputGlyphs.Display.UI.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/GamepadGlyphInitializer.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/GamepadGlyphInitializer.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using InputGlyphs.Loaders.Utils;
 using UnityEngine;
 

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/GamepadGlyphLoader.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/GamepadGlyphLoader.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using InputGlyphs.Loaders.Utils;
 using InputGlyphs.Utils;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/InputGlyphs.Loaders.Gamepad.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Gamepad/InputGlyphs.Loaders.Gamepad.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Keyboard/InputGlyphs.Loaders.Keyboard.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Keyboard/InputGlyphs.Loaders.Keyboard.asmdef
@@ -12,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Keyboard/KeyboardGlyphInitializer.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Keyboard/KeyboardGlyphInitializer.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using InputGlyphs.Loaders.Utils;
 using UnityEngine.InputSystem;
 

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Mouse/InputGlyphs.Loaders.Mouse.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Mouse/InputGlyphs.Loaders.Mouse.asmdef
@@ -12,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Mouse/MouseGlyphInitializer.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Mouse/MouseGlyphInitializer.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using InputGlyphs.Loaders.Utils;
 using UnityEngine.InputSystem;
 

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/SteamGamepad/InputGlyphs.Loaders.Steam.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/SteamGamepad/InputGlyphs.Loaders.Steam.asmdef
@@ -17,6 +17,11 @@
     "defineConstraints": [],
     "versionDefines": [
         {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        },
+        {
             "name": "com.eviltwo.unity-steam-input-adapter",
             "expression": "",
             "define": "SUPPORT_ADAPTER"

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/DeviceGlyphLoader.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/DeviceGlyphLoader.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using InputGlyphs.Utils;
 using UnityEngine;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/DeviceGlyphLoaderInitializer.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/DeviceGlyphLoaderInitializer.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/InputGlyphs.Loaders.Utils.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Loaders/Utils/InputGlyphs.Loaders.Utils.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputActionRebindingExtensions.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputActionRebindingExtensions.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputGlyphs.Utils.asmdef
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputGlyphs.Utils.asmdef
@@ -11,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "INPUT_SYSTEM"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputLayoutPathUtility.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Utils/InputLayoutPathUtility.cs
@@ -1,4 +1,4 @@
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine.InputSystem;


### PR DESCRIPTION
Fixed an error that appeared when InputSystem(new) was selected in PlayerSettings and the InputSystem package was not imported.