### PR TITLE
Changed to use the parent path if the image cannot be found.

### DIFF
--- a/InputGlyphs/Assets/InputGlyphs/CHANGELOG.md
+++ b/InputGlyphs/Assets/InputGlyphs/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [1.2.2] - Development
 ### Modified
 - Supported `DISABLESTEAMWORKS` Assembly Definition.
+- Changed to use the parent path if the image cannot be found.
+  - Example: `leftStick/x` -> `leftStick`
 
 ## [1.2.1] - 2024-10-31
 ### Modified

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/InputGlyphManager.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/InputGlyphManager.cs
@@ -1,5 +1,6 @@
 #if INPUT_SYSTEM && ENABLE_INPUT_SYSTEM
 using System.Collections.Generic;
+using InputGlyphs.Utils;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -45,7 +46,16 @@ namespace InputGlyphs
                     return true;
                 }
             }
-            return false;
+
+            var parentPath = InputLayoutPathUtility.GetParent(inputLayoutPath);
+            if (string.IsNullOrEmpty(parentPath))
+            {
+                return false;
+            }
+            else
+            {
+                return LoadGlyph(texture, activeDevices, parentPath);
+            }
         }
     }
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Utils/InputLayoutPathUtility.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Utils/InputLayoutPathUtility.cs
@@ -38,6 +38,26 @@ namespace InputGlyphs.Utils
         }
 
         /// <summary>
+        /// Get the parent path of the input layout path.
+        /// </summary>
+        /// <remarks>
+        /// Example: /leftStick/x -> /leftStick
+        /// </remarks>
+        public static string GetParent(string inputLayoutPath)
+        {
+            if (string.IsNullOrEmpty(inputLayoutPath))
+            {
+                return string.Empty;
+            }
+            var lastSeparatorIndex = inputLayoutPath.LastIndexOf(InputControlPath.Separator);
+            if (lastSeparatorIndex == -1)
+            {
+                return string.Empty;
+            }
+            return inputLayoutPath.Substring(0, lastSeparatorIndex);
+        }
+
+        /// <summary>
         /// Searches for bindings within actions that match the control scheme and returns the effective paths.
         /// </summary>
         /// <param name="action">Target action</param>

--- a/InputGlyphs/Assets/InputGlyphsTests/Utils/InputLayoutPathUtilityTest.cs
+++ b/InputGlyphs/Assets/InputGlyphsTests/Utils/InputLayoutPathUtilityTest.cs
@@ -19,5 +19,18 @@ namespace InputGlyphs.Tests
             var result = InputLayoutPathUtility.RemoveRoot(input);
             Assert.AreEqual(expected, result);
         }
+
+        [TestCase("/leftStick/x", "/leftStick")]
+        [TestCase("/leftStick", "")]
+        [TestCase("/leftStick/x/y", "/leftStick/x")]
+        [TestCase("leftStick/x", "leftStick")]
+        [TestCase("leftStick", "")]
+        [TestCase("leftStick/x/y", "leftStick/x")]
+        [TestCase("", "")]
+        public void GetParent(string input, string expected)
+        {
+            var result = InputLayoutPathUtility.GetParent(input);
+            Assert.AreEqual(expected, result);
+        }
     }
 }


### PR DESCRIPTION
Example: `leftStick/x` -> `leftStick`