### PR TITLE
Fix IndexOutOfRangeException when input action references array is too large

### DIFF
--- a/InputGlyphs/Assets/InputGlyphs/CHANGELOG.md
+++ b/InputGlyphs/Assets/InputGlyphs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.8]
+### Fixed
+- Fixed an error that occurred when too many actions were assigned to Input Action References in Input Glyph Text.
+
 ## [1.2.7]
 ### Fixed
 - Fixed an issue where the same glyph could be displayed for a single input.

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
@@ -183,6 +183,7 @@ namespace InputGlyphs.Display
             }
 
             _actionTextureIndexes.Clear();
+            var assignedTextureCount = 0;
             for (var i = 0; i < InputActionReferences.Length; i++)
             {
                 var actionReference = InputActionReferences[i];
@@ -196,19 +197,23 @@ namespace InputGlyphs.Display
                 if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer))
                 {
                     Texture2D texture;
-                    if (i < _actionTextureBuffer.Count)
+                    var textureIndex = assignedTextureCount;
+                    if (textureIndex < _actionTextureBuffer.Count)
                     {
-                        texture = _actionTextureBuffer[i];
+                        texture = _actionTextureBuffer[textureIndex];
                     }
                     else
                     {
                         texture = new Texture2D(2, 2);
                         _actionTextureBuffer.Add(texture);
                     }
+                    
                     if (DisplayGlyphTextureGenerator.GenerateGlyphTexture(texture, devices, _pathBuffer, GlyphsLayoutData))
                     {
-                        _actionTextureIndexes.Add(Tuple.Create(playerInputAction.name, i));
+                        _actionTextureIndexes.Add(Tuple.Create(playerInputAction.name, textureIndex));
                     }
+                    
+                    assignedTextureCount++;
                 }
             }
             SetGlyphsToSpriteAsset(_actionTextureBuffer, _actionTextureIndexes);

--- a/InputGlyphs/Assets/InputGlyphs/package.json
+++ b/InputGlyphs/Assets/InputGlyphs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.eviltwo.input-glyphs",
     "displayName": "Input Glyphs",
-    "version": "1.2.7",
+    "version": "1.2.8",
     "unity": "2022.3",
     "description": "Displays glyphs (icons) of keyboard & mouse or controller buttons recognized by Unity's InputSystem.",
     "author": {


### PR DESCRIPTION
fix https://github.com/eviltwo/InputGlyphs/issues/99