### PR TITLE
Texture fallback

### DIFF
--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/Sprite/InputGlyphSprite.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/Sprite/InputGlyphSprite.cs
@@ -24,6 +24,7 @@ namespace InputGlyphs.Display
         private PlayerInput _lastPlayerInput;
         private List<string> _pathBuffer = new List<string>();
         private Texture2D _texture;
+        private Sprite _createdSprite;
 
         private void Reset()
         {
@@ -69,9 +70,10 @@ namespace InputGlyphs.Display
         {
             Destroy(_texture);
             _texture = null;
+            Destroy(_createdSprite);
+            _createdSprite = null;
             if (SpriteRenderer != null)
             {
-                Destroy(SpriteRenderer.sprite);
                 SpriteRenderer.sprite = null;
             }
         }
@@ -162,14 +164,25 @@ namespace InputGlyphs.Display
             }
 
             var playerInputAction = playerInput.actions.FindAction(InputActionReference.action.id);
-            if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer))
+            if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer)
+                && DisplayGlyphTextureGenerator.GenerateGlyphTexture(_texture, devices, _pathBuffer, GlyphsLayoutData))
             {
-                if (DisplayGlyphTextureGenerator.GenerateGlyphTexture(_texture, devices, _pathBuffer, GlyphsLayoutData))
-                {
-                    Destroy(SpriteRenderer.sprite);
-                    SpriteRenderer.sprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
-                }
+                Destroy(_createdSprite);
+                _createdSprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
+                SpriteRenderer.sprite = _createdSprite;
             }
+            else
+            {
+                HandleGlyphTextureGenerationFailed();
+            }
+        }
+        
+        protected virtual void HandleGlyphTextureGenerationFailed()
+        {
+            _texture.Reinitialize(8, 8);
+            Destroy(_createdSprite);
+            _createdSprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
+            SpriteRenderer.sprite = _createdSprite;
         }
     }
 }

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
@@ -14,8 +14,6 @@ namespace InputGlyphs.Display
 {
     public class InputGlyphText : MonoBehaviour
     {
-        public static int PackedTextureSize = 2048;
-
         [SerializeField]
         public TMP_Text Text = null;
 
@@ -192,29 +190,34 @@ namespace InputGlyphs.Display
                     Debug.LogWarning("InputActionReference is not set.", this);
                     return;
                 }
+                
+                Texture2D texture;
+                var textureIndex = assignedTextureCount;
+                if (textureIndex < _actionTextureBuffer.Count)
+                {
+                    texture = _actionTextureBuffer[textureIndex];
+                }
+                else
+                {
+                    texture = new Texture2D(2, 2);
+                    _actionTextureBuffer.Add(texture);
+                }
 
+                var hasGeneratedGlyphTexture = false;
                 var playerInputAction = playerInput.actions.FindAction(actionReference.action.id);
                 if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer))
                 {
-                    Texture2D texture;
-                    var textureIndex = assignedTextureCount;
-                    if (textureIndex < _actionTextureBuffer.Count)
-                    {
-                        texture = _actionTextureBuffer[textureIndex];
-                    }
-                    else
-                    {
-                        texture = new Texture2D(2, 2);
-                        _actionTextureBuffer.Add(texture);
-                    }
-                    
-                    if (DisplayGlyphTextureGenerator.GenerateGlyphTexture(texture, devices, _pathBuffer, GlyphsLayoutData))
-                    {
-                        _actionTextureIndexes.Add(Tuple.Create(playerInputAction.name, textureIndex));
-                    }
-                    
-                    assignedTextureCount++;
+                    hasGeneratedGlyphTexture = DisplayGlyphTextureGenerator.GenerateGlyphTexture(texture, devices, _pathBuffer, GlyphsLayoutData);
                 }
+
+                // fallback
+                if (!hasGeneratedGlyphTexture)
+                {
+                    texture.Reinitialize(8, 8);
+                }
+                
+                _actionTextureIndexes.Add(Tuple.Create(playerInputAction.name, textureIndex));
+                assignedTextureCount++;
             }
             SetGlyphsToSpriteAsset(_actionTextureBuffer, _actionTextureIndexes);
 

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/TextMeshPro/InputGlyphText.cs
@@ -203,17 +203,15 @@ namespace InputGlyphs.Display
                     _actionTextureBuffer.Add(texture);
                 }
 
-                var hasGeneratedGlyphTexture = false;
                 var playerInputAction = playerInput.actions.FindAction(actionReference.action.id);
-                if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer))
+                if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer)
+                    && DisplayGlyphTextureGenerator.GenerateGlyphTexture(texture, devices, _pathBuffer, GlyphsLayoutData))
                 {
-                    hasGeneratedGlyphTexture = DisplayGlyphTextureGenerator.GenerateGlyphTexture(texture, devices, _pathBuffer, GlyphsLayoutData);
+                    // Glyph texture generation succeeded; the texture is updated in place.
                 }
-
-                // fallback
-                if (!hasGeneratedGlyphTexture)
+                else
                 {
-                    texture.Reinitialize(8, 8);
+                    HandleGlyphTextureGenerationFailed(texture);
                 }
                 
                 _actionTextureIndexes.Add(Tuple.Create(playerInputAction.name, textureIndex));
@@ -222,6 +220,11 @@ namespace InputGlyphs.Display
             SetGlyphsToSpriteAsset(_actionTextureBuffer, _actionTextureIndexes);
 
             Profiler.EndSample();
+        }
+        
+        protected virtual void HandleGlyphTextureGenerationFailed(Texture2D texture)
+        {
+            texture.Reinitialize(8, 8);
         }
 
         private void SetGlyphsToSpriteAsset(IReadOnlyList<Texture2D> actionTextures, IReadOnlyList<Tuple<string, int>> actionTextureIndexes)

--- a/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/UI/InputGlyphImage.cs
+++ b/InputGlyphs/Assets/InputGlyphs/Scripts/Runtime/Display/UI/InputGlyphImage.cs
@@ -175,15 +175,25 @@ namespace InputGlyphs.Display
             }
 
             var playerInputAction = playerInput.actions.FindAction(InputActionReference.action.id);
-            if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer))
+            if (InputLayoutPathUtility.TryGetActionBindingPath(playerInputAction, PlayerInput.currentControlScheme, _pathBuffer)
+                && DisplayGlyphTextureGenerator.GenerateGlyphTexture(_texture, devices, _pathBuffer, GlyphsLayoutData))
             {
-                if (DisplayGlyphTextureGenerator.GenerateGlyphTexture(_texture, devices, _pathBuffer, GlyphsLayoutData))
-                {
-                    Destroy(_createdSprite);
-                    _createdSprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
-                    Image.sprite = _createdSprite;
-                }
+                Destroy(_createdSprite);
+                _createdSprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
+                Image.sprite = _createdSprite;
             }
+            else
+            {
+                HandleGlyphTextureGenerationFailed();
+            }
+        }
+
+        protected virtual void HandleGlyphTextureGenerationFailed()
+        {
+            _texture.Reinitialize(8, 8);
+            Destroy(_createdSprite);
+            _createdSprite = Sprite.Create(_texture, new Rect(0, 0, _texture.width, _texture.height), new Vector2(0.5f, 0.5f), Mathf.Min(_texture.width, _texture.height));
+            Image.sprite = _createdSprite;
         }
 
         //


### PR DESCRIPTION
fixed https://github.com/eviltwo/InputGlyphs/issues/102

Example with the movement action removed from Input Actions:
<img width="766" height="337" alt="fallback_glyphs" src="https://github.com/user-attachments/assets/d9c4de39-7bd6-425d-b802-da42375a49e0" />
